### PR TITLE
Support signing into Firebase databases with Google OAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ Try rerunning the query.
 
 1. Find the app's Google OAuth Client ID (i.e. `NUMERIC_STR-ALPHANUMERIC_STR.apps.googleusercontent.com`). You can do this by clicking "Sign in with Google" on the site, inspecting the HTML, and searching for `apps.googleusercontent.com`.
 
-
 2. Edit your DNS file (`/etc/hosts` on Linux and macOS, `C:\Windows\system32\drivers\etc\hosts` on Windows) and add the following line:
 
 ```
@@ -86,16 +85,18 @@ openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout ./selfsigned.key -ou
 
 At the prompts, you can leave all fields blank except `Common Name (e.g. server FQDN or YOUR name) []`, which you should set to `PROJECT_ID.firebaseapp.com`.
 
-4. Edit `dist/index.html` and modify `TODO_SET_ME.apps.googleusercontent.com` to the Client ID you found in step 1.
+4. Clear all website data relating to `PROJECT_ID.firebaseapp.com` from your browser settings (alternatively, use a fresh browser) in order to prevent the browser from blocking your connection due to certificate mismatch (HSTS).
 
-5. Clear all website data relating to `PROJECT_ID.firebaseapp.com` from your browser settings (alternatively, use a fresh browser) in order to prevent the browser from blocking your connection due to certificate mismatch (HSTS).
+If you use DNS-over-TLS or DNS-over-HTTPS on the browser you're using for Baserunner, temporarily disable it in order to spoof the required origin for Google sign in on Firebase.
 
-5. Run Baserunner using ```sudo node index.js 443``` and then load `https://PROJECT_ID.firebaseapp.com` in your browser
+5. Run Baserunner using ```sudo node index.js 443``` and then load `https://PROJECT_ID.firebaseapp.com` in your browser.
 
-6. Click the Google sign-in button and sign in using the Google account you registered for the app with.
+6. Enter the Google OAuth Client you found in step 1 into the field under "Log in with Google" and click "Set Google client ID".
 
-7. Click the "Set google login" button.
+7. Click the Google sign-in button and sign in using the Google account you registered for the app with.
 
-8. Explore the database as you would with a non-Google account.
+8. Click the "Set Google login" button.
 
-9. When done security testing, remove the line from step 2 from your DNS file.
+9. Explore the database as you would with a non-Google account.
+
+10. When done security testing, remove the line from step 2 from your DNS file.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ At the prompts, you can leave all fields blank except `Common Name (e.g. server 
 
 4. Edit `dist/index.html` and modify `TODO_SET_ME.apps.googleusercontent.com` to the Client ID you found in step 1.
 
+5. Clear all website data relating to `PROJECT_ID.firebaseapp.com` from your browser settings (alternatively, use a fresh browser) in order to prevent the browser from blocking your connection due to certificate mismatch (HSTS).
+
 5. Run Baserunner using ```sudo node index.js 443``` and then load `https://PROJECT_ID.firebaseapp.com` in your browser
 
 6. Click the Google sign-in button and sign in using the Google account you registered for the app with.

--- a/README.md
+++ b/README.md
@@ -69,13 +69,16 @@ Try rerunning the query.
 
 **How do I log in with Google?**
 
-1. Edit your DNS file (`/etc/hosts` on Linux and macOS, `C:\Windows\system32\drivers\etc\hosts` on Windows) and add the following line:
+1. Find the app's Google OAuth Client ID (i.e. `NUMERIC_STR-ALPHANUMERIC_STR.apps.googleusercontent.com`). You can do this by clicking "Sign in with Google" on the site, inspecting the HTML, and searching for `apps.googleusercontent.com`.
+
+
+2. Edit your DNS file (`/etc/hosts` on Linux and macOS, `C:\Windows\system32\drivers\etc\hosts` on Windows) and add the following line:
 
 ```
 127.0.0.1 PROJECT_ID.firebaseapp.com
 ```
 
-2. In the Baserunner directory, run the following command to generate a self-signed certificate:
+3. In the Baserunner directory, run the following command to generate a self-signed certificate:
 
 ```
 openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout ./selfsigned.key -out selfsigned.crt
@@ -83,12 +86,14 @@ openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout ./selfsigned.key -ou
 
 At the prompts, you can leave all fields blank except `Common Name (e.g. server FQDN or YOUR name) []`, which you should set to `PROJECT_ID.firebaseapp.com`.
 
-3. Run Baserunner using ```sudo node index.js 443``` and then load `https://PROJECT_ID.firebaseapp.com` in your browser
+4. Edit `dist/index.html` and modify `TODO_SET_ME.apps.googleusercontent.com` to the Client ID you found in step 1.
 
-4. Click the Google sign-in button and sign in using the Google account you registered for the app with.
+5. Run Baserunner using ```sudo node index.js 443``` and then load `https://PROJECT_ID.firebaseapp.com` in your browser
 
-5. Click the "Set google login" button.
+6. Click the Google sign-in button and sign in using the Google account you registered for the app with.
 
-6. Explore the database as you would with a non-Google account.
+7. Click the "Set google login" button.
 
-7. When done security testing, remove the line from step 1 from your DNS file.
+8. Explore the database as you would with a non-Google account.
+
+9. When done security testing, remove the line from step 2 from your DNS file.

--- a/README.md
+++ b/README.md
@@ -67,3 +67,28 @@ While only the latest query result is displayed on the Baserunner page, all resu
 
 Try rerunning the query.
 
+**How do I log in with Google?**
+
+1. Edit your DNS file (`/etc/hosts` on Linux and macOS, `C:\Windows\system32\drivers\etc\hosts` on Windows) and add the following line:
+
+```
+127.0.0.1 PROJECT_ID.firebaseapp.com
+```
+
+2. In the Baserunner directory, run the following command to generate a self-signed certificate:
+
+```
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout ./selfsigned.key -out selfsigned.crt
+```
+
+At the prompts, you can leave all fields blank except `Common Name (e.g. server FQDN or YOUR name) []`, which you should set to `PROJECT_ID.firebaseapp.com`.
+
+3. Run Baserunner using ```sudo node index.js 443``` and then load `https://PROJECT_ID.firebaseapp.com` in your browser
+
+4. Click the Google sign-in button and sign in using the Google account you registered for the app with.
+
+5. Click the "Set google login" button.
+
+6. Explore the database as you would with a non-Google account.
+
+7. When done security testing, remove the line from step 1 from your DNS file.

--- a/dist/index.html
+++ b/dist/index.html
@@ -10,7 +10,6 @@
   <script src="https://www.google.com/recaptcha/api.js" async defer></script>
   <script src="main.js">
   </script>
-  <!-- <script src="googleauth.js"></script> -->
   <script type="text/javascript">
     function onSignIn(googleUser) {
       window.googleUser = googleUser;
@@ -42,8 +41,7 @@
 
       <div data-controller="login-google">
         <h2 data-login-google-target="status">Log in with Google</h2>
-        <div id="g_id_onload" data-client_id="REDACTED.apps.googleusercontent.com" data-callback="onSignIn" data-auto_prompt="false"></div>
-        <div class="g_id_signin" data-type="standard" data-size="large" data-theme="outline" data-text="sign_in_with" data-shape="rectangular" data-logo_alignment="left">
+        <div id="g_id_onload" data-client_id="TODO_SET_ME.apps.googleusercontent.com" data-callback="onSignIn" data-auto_prompt="false"></div>
         </div>
 
         <button type="submit" data-login-google-target="gbutton" data-action="click->login-google#login">Set google login</button>

--- a/dist/index.html
+++ b/dist/index.html
@@ -14,6 +14,28 @@
     function onSignIn(googleUser) {
       window.googleUser = googleUser;
     }
+
+    function insertGoogleSignIn() {
+      var gLoginSection = document.getElementById("login-google-section");
+      var gClientIdElement = document.getElementById("google-client-id");
+
+      google.accounts.id.initialize({
+        client_id: gClientIdElement.value,
+        callback: onSignIn
+      });
+      google.accounts.id.renderButton(
+        document.getElementById("gSignIn"),
+        { theme: "outline", size: "medium"}
+      );
+
+      gClientIdElement.disabled = true;
+      document.getElementById("set-google-client-id").hidden = true;
+      document.getElementById("set-google-login").hidden = false;
+    }
+
+    window.onload = function() {
+      document.getElementById("set-google-client-id").addEventListener("click", insertGoogleSignIn);
+    }
   </script>
   <link rel="stylesheet" href="style.css">
 </head>
@@ -39,12 +61,16 @@
         <button data-login-phone-target="otpbutton" type="submit" data-action="click->login-phone#sendcode">Submit code</button>
       </div>
 
-      <div data-controller="login-google">
+      <div data-controller="login-google" id="login-google-section">
         <h2 data-login-google-target="status">Log in with Google</h2>
-        <div id="g_id_onload" data-client_id="TODO_SET_ME.apps.googleusercontent.com" data-callback="onSignIn" data-auto_prompt="false"></div>
-        </div>
+        <input type="text" id="google-client-id"></input>
+        <input type="button" id="set-google-client-id" value="Set Google client ID"></input>
 
-        <button type="submit" data-login-google-target="gbutton" data-action="click->login-google#login">Set google login</button>
+        <br>
+        <div id="gSignIn"></div>
+        <br>
+
+        <button type="submit" id="set-google-login" data-login-google-target="gbutton" data-action="click->login-google#login" hidden>Set Google login</button>
       </div>
 
       <div data-controller="config">

--- a/dist/index.html
+++ b/dist/index.html
@@ -2,8 +2,19 @@
 <html>
 <head>
   <meta charset="utf-8">
+  <script src="https://accounts.google.com/gsi/client" async defer></script>
+  <script src="https://www.gstatic.com/firebasejs/7.14.5/firebase-app.js"></script>
+  <link type="text/css" rel="stylesheet" href="https://www.gstatic.com/firebasejs/ui/4.4.0/firebase-ui-auth.css" />
+  <script src="https://www.gstatic.com/firebasejs/7.8.0/firebase-auth.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/ui/4.4.0/firebase-ui-auth.js"></script>
   <script src="https://www.google.com/recaptcha/api.js" async defer></script>
   <script src="main.js">
+  </script>
+  <!-- <script src="googleauth.js"></script> -->
+  <script type="text/javascript">
+    function onSignIn(googleUser) {
+      window.googleUser = googleUser;
+    }
   </script>
   <link rel="stylesheet" href="style.css">
 </head>
@@ -27,6 +38,15 @@
         <button data-login-phone-target="button" id="login-phone-button" type="submit" data-action="click->login-phone#login">Log in</button>
         <div id="g-recaptcha"></div>
         <button data-login-phone-target="otpbutton" type="submit" data-action="click->login-phone#sendcode">Submit code</button>
+      </div>
+
+      <div data-controller="login-google">
+        <h2 data-login-google-target="status">Log in with Google</h2>
+        <div id="g_id_onload" data-client_id="REDACTED.apps.googleusercontent.com" data-callback="onSignIn" data-auto_prompt="false"></div>
+        <div class="g_id_signin" data-type="standard" data-size="large" data-theme="outline" data-text="sign_in_with" data-shape="rectangular" data-logo_alignment="left">
+        </div>
+
+        <button type="submit" data-login-google-target="gbutton" data-action="click->login-google#login">Set google login</button>
       </div>
 
       <div data-controller="config">

--- a/index.js
+++ b/index.js
@@ -1,7 +1,17 @@
 const express = require('express');
+const fs = require('fs');
+const https = require('https');
 const app = express();
 const path = require('path');
  
 app.use(express.static('dist'));
- 
-app.listen(3000);
+
+if (process.argv[2] == '443') {
+    var options = {
+        key: fs.readFileSync('selfsigned.key'),
+        cert: fs.readFileSync('selfsigned.crt')
+    }
+    https.createServer(options, app).listen(443);
+} else {
+    app.listen(parseInt(process.argv[2]));
+}

--- a/index.js
+++ b/index.js
@@ -13,5 +13,8 @@ if (process.argv[2] == '443') {
     }
     https.createServer(options, app).listen(443);
 } else {
-    app.listen(parseInt(process.argv[2]));
+    var port = 3000;
+    if (process.argv[2])
+        port = parseInt(process.argv[2]);
+    app.listen(port);
 }

--- a/src/controllers/login_google_controller.js
+++ b/src/controllers/login_google_controller.js
@@ -9,7 +9,6 @@ export default class extends Controller {
         }
 
     login() {
-        console.log(window.googleUser);
         if (!window.firebaseConfig) {
             alert("Set config first!");
             return;

--- a/src/controllers/login_google_controller.js
+++ b/src/controllers/login_google_controller.js
@@ -1,0 +1,26 @@
+import { Controller } from "stimulus"
+import firebase from "firebase/app"
+import "firebase/auth"
+
+export default class extends Controller {
+
+    static get targets() {
+        return [ "gsignin", "gbutton", "status" ]
+        }
+
+    login() {
+        console.log(window.googleUser);
+        if (!window.firebaseConfig) {
+            alert("Set config first!");
+            return;
+        }
+
+        var credential = firebase.auth.GoogleAuthProvider.credential(window.googleUser.credential);
+        firebase.auth().signInWithCredential(credential)
+            .then((userCredential) => {
+                window.firebaseUser = userCredential.user
+
+                this.statusTarget.innerHTML = "Logged in with Google!"
+            });
+    }
+}


### PR DESCRIPTION
Following from #2, this PR adds support for signing in with Google OAuth to Firebase databases. ~~Currently the setup is somewhat janky and requires editing `index.html`, a fix for that is coming shortly.~~ fixed

The user may also need to edit their local DNS hosts file, but that does not seem like something that can be changed on the baserunner end.